### PR TITLE
chore: update ktsu.Sdk to 2.21.1 [patch]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,9 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 tab_width = 4
-end_of_line = crlf
+# LF on every platform, matching the `* text=auto eol=lf` default in .gitattributes.
+# Overrides below must stay in step with the eol pins in that file.
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
@@ -17,7 +19,7 @@ trim_trailing_whitespace = true
 [*.{cs,csx,cake,fs,fsx,vb,vbx}]
 indent_style = tab
 
-file_header_template = Copyright (c) ktsu.dev\nAll rights reserved.\nLicensed under the MIT license.
+file_header_template = Copyright (c) 2023-2026 ktsu-dev contributors
 
 # Default severity for all .NET Code Style rules
 dotnet_analyzer_diagnostic.severity = error
@@ -504,3 +506,8 @@ indent_style = tab
 [*.sh]
 end_of_line = lf
 indent_size = 2
+
+# Windows batch scripts and Visual Studio solution files keep CRLF on every platform.
+# These match the eol=crlf pins in .gitattributes.
+[*.{cmd,bat,sln}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,20 +4,25 @@
 # Git Line Endings            #
 ###############################
 
-# Set default behaviour to automatically normalize line endings.
-* text=auto
+# Normalize all text files to LF in the repository, and check them out as LF on every
+# platform. The explicit eol overrides each machine's core.autocrlf, so the working tree
+# is byte-identical on Windows, Linux and macOS. This must stay in step with the
+# end_of_line settings in .editorconfig.
+* text=auto eol=lf
 
-# csharp files to match .editorconfig
-*.cs text eol=crlf
+# Force bash scripts to always use LF line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work. Redundant with the
+# default above, kept explicit because these files break outright with CRLF.
+*.sh text eol=lf
 
 # Force batch scripts to always use CRLF line endings so that if a repo is accessed
 # in Windows via a file share from Linux, the scripts will work.
-*.{cmd,[cC][mM][dD]} text eol=crlf
-*.{bat,[bB][aA][tT]} text eol=crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
 
-# Force bash scripts to always use LF line endings so that if a repo is accessed
-# in Unix via a file share from Windows, the scripts will work.
-*.sh text eol=lf
+# Visual Studio rewrites solution files with CRLF regardless of the checkout, so pin
+# them to avoid a spurious whole-file diff every time the solution is opened.
+*.sln text eol=crlf
 
 ###############################
 # Git Large File System (LFS) #

--- a/.runsettings
+++ b/.runsettings
@@ -1,25 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
-  <!-- Specify a deterministic output directory -->
   <RunConfiguration>
-    <ResultsDirectory>.\coverage</ResultsDirectory>
+    <ResultsDirectory>TestResults</ResultsDirectory>
   </RunConfiguration>
-  <!-- Specify a deterministic output directory -->
-  <RunConfiguration>
-    <ResultsDirectory>.\coverage</ResultsDirectory>
-  </RunConfiguration>
-
-  <!-- Configuration for coverlet data collector -->
-  <DataCollectionRunSettings>
-    <DataCollectors>
-      <DataCollector friendlyName="XPlat Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="coverlet.collector.DataCollectors.CoverletInProcDataCollector, coverlet.collector, Version=6.0.4.0, Culture=neutral, PublicKeyToken=null">
-        <Configuration>
-          <Format>opencover</Format>
-          <OutputPath>coverage.opencover.xml</OutputPath>
-          <Exclude>[*Test*]*,[*Tests*]*</Exclude>
-          <ExcludeByFile>**/obj/**/*</ExcludeByFile>
-        </Configuration>
-      </DataCollector>
-    </DataCollectors>
-  </DataCollectionRunSettings>
 </RunSettings>

--- a/ScopedAction.Tests/ScopedActionTests.cs
+++ b/ScopedAction.Tests/ScopedActionTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 [assembly: Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize(Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel)]
 

--- a/ScopedAction/ScopedAction.cs
+++ b/ScopedAction/ScopedAction.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ScopedAction;
 

--- a/global.json
+++ b/global.json
@@ -5,15 +5,15 @@
   },
   "msbuild-sdks": {
     "MSTest.Sdk": "4.3.3",
-    "ktsu.Sdk": "2.18.0",
-    "ktsu.Sdk.ConsoleApp": "2.18.0",
-    "ktsu.Sdk.Tool": "2.18.0",
-    "ktsu.Sdk.App": "2.18.0",
-    "ktsu.Sdk.Windows": "2.18.0",
-    "ktsu.Sdk.Linux": "2.18.0",
-    "ktsu.Sdk.macOS": "2.18.0",
-    "ktsu.Sdk.iOS": "2.18.0",
-    "ktsu.Sdk.Android": "2.18.0"
+    "ktsu.Sdk": "2.21.1",
+    "ktsu.Sdk.ConsoleApp": "2.21.1",
+    "ktsu.Sdk.Tool": "2.21.1",
+    "ktsu.Sdk.App": "2.21.1",
+    "ktsu.Sdk.Windows": "2.21.1",
+    "ktsu.Sdk.Linux": "2.21.1",
+    "ktsu.Sdk.macOS": "2.21.1",
+    "ktsu.Sdk.iOS": "2.21.1",
+    "ktsu.Sdk.Android": "2.21.1"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
Bumps ktsu.Sdk and its variants to 2.21.1 in global.json.  File headers are migrated to the single line from COPYRIGHT.md, which is what the SDK writes into .editorconfig as file_header_template and IDE0073 enforces.  

Generated with [Claude Code](https://claude.com/claude-code)
